### PR TITLE
Bug-fixing and generic improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Qt Creator files
+build
+*.user
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 
+
+if(UNIX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif(UNIX)
+
+
 set(HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/lib/backpack/archive/archive.h
                  ${CMAKE_CURRENT_SOURCE_DIR}/lib/backpack/archive/bufferarchive.h
                  ${CMAKE_CURRENT_SOURCE_DIR}/lib/backpack/archive/jsonarchive.h

--- a/example/bar.cpp
+++ b/example/bar.cpp
@@ -6,6 +6,11 @@ Bar::Bar() :
 
 }
 
+Bar::~Bar()
+{
+
+}
+
 const Foo& Bar::get_foo() const
 {
     return foo;

--- a/example/bar.h
+++ b/example/bar.h
@@ -9,6 +9,7 @@ class Bar : public Archivable
 {
 public:
     Bar();
+    virtual ~Bar();
 
     void write_to_archive(Archive& archive) const override;
     void read_from_archive(const Archive& archive) override;

--- a/example/baz.h
+++ b/example/baz.h
@@ -12,7 +12,7 @@ class Baz : public Archivable
 {
 public:
     Baz();
-    ~Baz();
+    virtual ~Baz();
 
     void write_to_archive(Archive& archive) const override;
     void read_from_archive(const Archive& archive) override;

--- a/example/foo.cpp
+++ b/example/foo.cpp
@@ -6,6 +6,11 @@ Foo::Foo() :
 
 }
 
+Foo::~Foo()
+{
+
+}
+
 int64_t Foo::get_value() const
 {
     return value;

--- a/example/foo.h
+++ b/example/foo.h
@@ -9,6 +9,7 @@ class Foo : public Archivable
 {
 public:
     Foo();
+    virtual ~Foo();
 
     int64_t get_value() const;
     void set_value(const int64_t &value);

--- a/example/fred.cpp
+++ b/example/fred.cpp
@@ -6,6 +6,11 @@ Fred::Fred()
 
 }
 
+Fred::~Fred()
+{
+
+}
+
 void Fred::serialize(std::string &out_string) const
 {
     std::ostringstream oss;

--- a/example/fred.h
+++ b/example/fred.h
@@ -8,6 +8,7 @@ class Fred : public Serializable
 {
 public:
     Fred();
+    virtual ~Fred();
 
     // Serializable interface
     void serialize(std::string &out_string) const override;

--- a/lib/backpack/archive/bufferarchive.cpp
+++ b/lib/backpack/archive/bufferarchive.cpp
@@ -18,6 +18,7 @@
  */
 #include "bufferarchive.h"
 #include <stdlib.h>
+#include <cstring>
 
 BufferArchive::BufferArchive()
 {

--- a/lib/backpack/archive/bufferarchive.cpp
+++ b/lib/backpack/archive/bufferarchive.cpp
@@ -25,9 +25,13 @@ BufferArchive::BufferArchive()
     init_state();
 }
 
-BufferArchive::BufferArchive(uint8_t *data, const size_t& size)
-    :m_data(data), m_data_size(size)
+BufferArchive::BufferArchive(const uint8_t *data, const size_t& size)
+    :m_data(nullptr), m_data_size(size)
 {
+    // Copy the input data
+    m_data = (uint8_t*)malloc(m_data_size);
+    memcpy(m_data, data, m_data_size);
+
     m_data_capacity = 0;
     m_data_pos = 0;
 }
@@ -364,7 +368,10 @@ void BufferArchive::init_state()
 
 void BufferArchive::free_data_no_init()
 {
-    if (m_data) free(m_data);
+    if (m_data)
+        free(m_data);
+
+    m_data = nullptr;
 }
 
 void BufferArchive::free_data()

--- a/lib/backpack/archive/bufferarchive.h
+++ b/lib/backpack/archive/bufferarchive.h
@@ -24,7 +24,7 @@ class BufferArchive : public Archive
 {
 public:
     BufferArchive();
-    BufferArchive(uint8_t *data, const size_t& size);
+    BufferArchive(const uint8_t *data, const size_t& size);
     ~BufferArchive();
 
     uint8_t* get_data() const;


### PR DESCRIPTION
This PR fixes a double free bug and other small fixes.

* The `BufferArchive` class owns the internal memory and make a copy of the data passed from the constructor.
* Added virtual destructor to example classes
* Add C++11 flag to compiler
* Add missing header